### PR TITLE
Add fwd_from source to RSS items

### DIFF
--- a/app/RSS/Feed.php
+++ b/app/RSS/Feed.php
@@ -69,6 +69,17 @@ class Feed {
             //Standard stuff
             if (!empty($item['id'])) $newItem->addChild('guid', $item['id']);
             if (!empty($item['title'])) $newItem->addChild('title', htmlspecialchars($item['title'], ENT_XML1));
+            if (!empty($item['fwd_from'])) {
+                $sourceUrl = $item['fwd_from']['saved_from_url'] ?? null;
+                if (!$sourceUrl && !empty($item['fwd_from']['from_id']['channel_id']) && !empty($item['fwd_from']['channel_post'])) {
+                    $sourceUrl = sprintf('https://t.me/c/%s/%s', $item['fwd_from']['from_id']['channel_id'], $item['fwd_from']['channel_post']);
+                }
+                if ($sourceUrl) {
+                    $sourceTitle = $item['fwd_from']['from_name'] ?? '';
+                    $source = $newItem->addChild('source', htmlspecialchars($sourceTitle, ENT_XML1));
+                    $source->addAttribute('url', $sourceUrl);
+                }
+            }
             if (!empty($item['description']) || !empty($item['preview']) || !empty($item['webpage'])) {
                 $description = '';
                 foreach ($item['preview'] as $url) {

--- a/app/RSS/Messages.php
+++ b/app/RSS/Messages.php
@@ -74,6 +74,7 @@ class Messages
                         'timestamp' => $message['date'] ?? '',
                         'views' => $message['views'] ?? null,
                         'reactions' => null,
+                        'fwd_from' => $message['fwd_from'] ?? null,
                     ];
 
                     if (!empty($message['reactions']['results'])) {


### PR DESCRIPTION
## Summary
- include fwd_from data when parsing messages
- render forwarded message source in RSS `<source>` element

## Testing
- `php -l app/RSS/Messages.php`
- `php -l app/RSS/Feed.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68a8654dee74832f8b101c76bd57763d